### PR TITLE
fix: code fixes and readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# react-native-react-native-active-keyboards [![Node version](https://badge.fury.io/js/react-native-active-keyboards.svg)](http://nodejs.org/download/)
+# react-native-active-keyboards [![Node version](https://badge.fury.io/js/react-native-active-keyboards.svg)](http://nodejs.org/download/)
 
 This is a simple module to let you determine if a specific keyboard is installed. Particularly useful if you have created your own custom keyboard.
 
@@ -6,9 +6,9 @@ This is a simple module to let you determine if a specific keyboard is installed
 
 `$ npm install react-native-active-keyboards --save`
 
-### Mostly automatic installation
+### For iOS
 
-`$ react-native link react-native-active-keyboards`
+`cd ios` && `pod install`
 
 ### Manual installation
 
@@ -23,8 +23,8 @@ This is a simple module to let you determine if a specific keyboard is installed
 
 1.  Open up `android/app/src/main/java/[...]/MainActivity.java`
 
-* Add `import com.reactlibrary.RNReactNativeActiveKeyboardsPackage;` to the imports at the top of the file
-* Add `new RNReactNativeActiveKeyboardsPackage()` to the list returned by the `getPackages()` method
+- Add `import com.reactlibrary.RNReactNativeActiveKeyboardsPackage;` to the imports at the top of the file
+- Add `new RNReactNativeActiveKeyboardsPackage()` to the list returned by the `getPackages()` method
 
 2.  Append the following lines to `android/settings.gradle`:
     ```
@@ -39,13 +39,18 @@ This is a simple module to let you determine if a specific keyboard is installed
 ## Usage
 
 ```javascript
-import { keyboardEnabled } from "react-native-active-keyboards";
+import { keyboardEnabled, getAllKeyboards } from "react-native-active-keyboards";
 
 [...]
   async componentWillMount() {
     // @param keyboardId
     const enabled = await keyboardEnabled("keyboardName");
     console.log("IN APP", enabled);
+
+    // Get all keyboards
+    const keyboards = await getAllkeyboards();
+     // returns Array
+    console.log("Keyboards", keyboards)
   }
 [...]
 ```

--- a/RNReactNativeActiveKeyboards.podspec
+++ b/RNReactNativeActiveKeyboards.podspec
@@ -9,12 +9,12 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNReactNativeActiveKeyboards
                    DESC
-  s.homepage     = "https://github.com/author/RNReactNativeActiveKeyboards"
+  s.homepage     = "https://github.com/jim-at-jibba/react-native-active-keyboards.git"
   s.license      = "MIT"
   # s.license    = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author       = { "author" => "author@domain.cn" }
-  s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/RNReactNativeActiveKeyboards.git", :tag => "#{s.version}" }
+  s.platform     = :ios, "11.0"
+  s.source       = { :git => "https://github.com/jim-at-jibba/react-native-active-keyboards.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m}"
   s.requires_arc = true

--- a/index.js
+++ b/index.js
@@ -26,3 +26,8 @@ export const keyboardEnabled = async key => {
     throw error;
   }
 };
+
+export const getAllKeyboards = async () => {
+  const keyboards = await RNReactNativeActiveKeyboards.keyboardEnabled();
+  return Platform.OS === 'ios' ? keyboards : keyboards.split(',')
+}

--- a/ios/RNReactNativeActiveKeyboards.m
+++ b/ios/RNReactNativeActiveKeyboards.m
@@ -3,16 +3,8 @@
 
 @implementation RNReactNativeActiveKeyboards
 
-- (dispatch_queue_t)methodQueue
-{
-    return dispatch_get_main_queue();
-}
-RCT_EXPORT_MODULE()
 
-- (NSDictionary *)constantsToExport
-{
-    return @{ @"initialExtensions": [[[NSUserDefaults standardUserDefaults] dictionaryRepresentation] objectForKey:@"AppleKeyboards"]};
-}
+RCT_EXPORT_MODULE()
 
 RCT_REMAP_METHOD(keyboardEnabled,
                  findEventsWithResolver:(RCTPromiseResolveBlock)resolve
@@ -23,10 +15,7 @@ RCT_REMAP_METHOD(keyboardEnabled,
     
 }
 
-+ (BOOL)requiresMainQueueSetup
-{
-  return YES;
-}
+
 
 @end
   


### PR DESCRIPTION
- [x] Fix(iOS): Doesn't require a need to set up the main queue (should work on background thread as well), and `constantsToExport` looks redundant.
- [x] Feat: Adds API to get all keyboards `getAllKeyboards` 
- [x] chore(podspec): Author info and platform version updated to 11
- [x] chore(readme): Docs updated 